### PR TITLE
allowing non-string bodies in HTTPResponses

### DIFF
--- a/imposter.go
+++ b/imposter.go
@@ -239,8 +239,8 @@ type HTTPResponse struct {
 	StatusCode int
 	// Headers are the HTTP headers in the response.
 	Headers map[string]string
-	// Body is the body of the response.
-	Body string
+	// Body is the body of the response. It will be JSON encoded before sending to mountebank
+	Body interface{}
 	// Mode is the mode of the response; either "text" or "binary".
 	// Defaults to "text" if excluded.
 	Mode string
@@ -251,7 +251,7 @@ type HTTPResponse struct {
 type httpResponseDTO struct {
 	StatusCode int               `json:"statusCode,omitempty"`
 	Headers    map[string]string `json:"headers,omitempty"`
-	Body       string            `json:"body,omitempty"`
+	Body       interface{}       `json:"body,omitempty"`
 	Mode       string            `json:"_mode,omitempty"`
 }
 

--- a/imposter_test.go
+++ b/imposter_test.go
@@ -154,6 +154,83 @@ func TestImposter_MarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			Description: "should marshal non-string bodies to JSON",
+			Imposter: mbgo.Imposter{
+				Port:           8080,
+				Proto:          "http",
+				Name:           "http_test_imposter",
+				RecordRequests: true,
+				AllowCORS:      true,
+				Stubs: []mbgo.Stub{
+					{
+						Predicates: []mbgo.Predicate{
+							{
+								Operator: "equals",
+								Request: mbgo.HTTPRequest{
+									RequestFrom: net.IPv4(172, 17, 0, 1),
+									Method:      http.MethodGet,
+									Path:        "/foo",
+									Headers: map[string]string{
+										"Accept": "application/json",
+									},
+								},
+							},
+						},
+						Responses: []mbgo.Response{
+							{
+								Type: "is",
+								Value: mbgo.HTTPResponse{
+									StatusCode: http.StatusOK,
+									Headers: map[string]string{
+										"Content-Type": "application/json",
+									},
+									Body: struct{
+										Test bool `json:"test"`
+									}{
+										Test: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Expected: map[string]interface{}{
+				"port":           8080,
+				"protocol":       "http",
+				"name":           "http_test_imposter",
+				"recordRequests": true,
+				"allowCORS":      true,
+				"stubs": []interface{}{
+					map[string]interface{}{
+						"predicates": []interface{}{
+							map[string]interface{}{
+								"equals": map[string]interface{}{
+									"requestFrom": "172.17.0.1",
+									"method":      http.MethodGet,
+									"path":        "/foo",
+									"headers": map[string]string{
+										"Accept": "application/json",
+									},
+								},
+							},
+						},
+						"responses": []interface{}{
+							map[string]interface{}{
+								"is": map[string]interface{}{
+									"statusCode": 200,
+									"headers": map[string]string{
+										"Content-Type": "application/json",
+									},
+									"body": map[string]interface{}{"test": true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			Description: "should include parameters on the predicate if specified",
 			Imposter: mbgo.Imposter{
 				Port:           8080,


### PR DESCRIPTION
The `HTTPResponse` `body` field may be a string or an object: http://www.mbtest.org/docs/protocols/http

Changing `body` to an `interface{}` from `string`, as allows stubs to be written more succinctly.