### PR TITLE
Smotes/mountebank 1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ language: go
 go:
     - 1.9
     - "1.10"
+    - "1.11"
     - tip
 
 before_install:
-    - docker pull andyrbell/mountebank:1.14.1
+    - make pull
     - make tools
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ fmt:
 lint:
 	@golint -set_exit_status $(GOPACKAGES)
 
+.PHONY: pull
+pull:
+	@docker pull andyrbell/mountebank:1.16.0
+
 .PHONY: unit
 unit:
 	@go test -cover -short $(GOPACKAGES)

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ $ make unit
 $ make integration
 ```
 
-The integration test client points to a local Docker container at port 2525, with the additional ports 8080-8083 exposed for communication with test imposters. Currently tested against a mountebank v1.14.1 instance.
+The integration test client points to a local Docker container at port 2525, with the additional ports 8080-8083 exposed for communication with test imposters. Currently tested against a mountebank v1.16.0 instance.
 
 ## Contributing
 
 * Fork the repository.
 * Code your changes.
 * If applicable, add tests and/or documentation.
-* Please ensure all unit and integration tests are passing, and that all code passes `make lint` and `make vet`.
+* Please ensure all unit and integration tests are passing, and that all code passes `make lint`.
 * Raise a new pull request with a short description of your changes.
+* Use the following convention for branch naming: `<username>/<description-with-dashes>`. For instance, `smotes/add-smtp-imposters`.

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 
 	ctx := context.Background()
 	cli := mustNewDockerClient()
-	image := "andyrbell/mountebank:1.14.1"
+	image := "andyrbell/mountebank:1.16.0"
 
 	var (
 		id  string
@@ -80,7 +80,7 @@ func TestClient_Logs(t *testing.T) {
 	vs, err := mb.Logs(-1, -1)
 	testutil.ExpectEqual(t, err, nil)
 	testutil.ExpectEqual(t, len(vs) >= 2, true)
-	testutil.ExpectEqual(t, vs[0].Message, "[mb:2525] mountebank v1.14.1 now taking orders - point your browser to http://localhost:2525 for help")
+	testutil.ExpectEqual(t, vs[0].Message, "[mb:2525] mountebank v1.16.0 now taking orders - point your browser to http://localhost:2525 for help")
 	testutil.ExpectEqual(t, vs[1].Message, "[mb:2525] GET /logs")
 }
 
@@ -440,7 +440,7 @@ func TestClient_DeleteRequests(t *testing.T) {
 				Port:         8080,
 				Proto:        "http",
 				Name:         "delete_requests_test",
-				RequestCount: 0,
+				RequestCount: 1,
 				Requests: []interface{}{
 					mbgo.HTTPRequest{
 						RequestFrom: net.IPv4(172, 17, 0, 1),
@@ -497,7 +497,7 @@ func TestClient_Config(t *testing.T) {
 
 	cfg, err := mb.Config()
 	testutil.ExpectEqual(t, err, nil)
-	testutil.ExpectEqual(t, cfg.Version, "1.14.1")
+	testutil.ExpectEqual(t, cfg.Version, "1.16.0")
 }
 
 func TestClient_Imposters(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,14 +1,19 @@
 package testutil
 
 import (
+	"fmt"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
 // ExpectEqual is a helper function used throughout the unit and integration
 // tests to assert deep equality between an actual and expected value.
-func ExpectEqual(t *testing.T, actual, expected interface{}) {
+func ExpectEqual(tb testing.TB, actual, expected interface{}) {
 	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("\nexpected:\n\t%+v\nto equal:\n\t%+v\n", actual, expected)
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, expected, actual)
+		tb.FailNow()
 	}
 }


### PR DESCRIPTION
These changes update the tests to run against a mountebank v1.16.0 instance, in addition to a couple of minor changes around the `Makefile` and internal `testutil` package.