### PR TITLE
smotes/v2.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ services:
 language: go
 
 go:
-  - "1.10"
-  - "1.11"
   - "1.12"
   - "1.13"
+  - "1.14"
+  - "1.15"
 
 script: make unit && make integration
 
@@ -18,4 +18,4 @@ jobs:
     - stage: check
       install: go get golang.org/x/lint/golint github.com/kisielk/errcheck
       script: make lint && make errcheck
-      go: "1.13" # only run source code analysis tools on latest version of Go
+      go: "1.15" # only run source code analysis tools on latest version of Go

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ services:
 language: go
 
 go:
-  - "1.12"
   - "1.13"
   - "1.14"
   - "1.15"
+  - "1.16"
 
 script: make unit && make integration
 
@@ -18,4 +18,4 @@ jobs:
     - stage: check
       install: go get golang.org/x/lint/golint github.com/kisielk/errcheck
       script: make lint && make errcheck
-      go: "1.15" # only run source code analysis tools on latest version of Go
+      go: "1.16" # only run source code analysis tools on latest version of Go

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ script: make unit && make integration
 jobs:
   include:
     - stage: check
-      install: go get golang.org/x/lint/golint github.com/kisielk/errcheck
-      script: make lint && make errcheck
+      install: go install golang.org/x/lint/golint@latest
+      script: make lint
       go: "1.16" # only run source code analysis tools on latest version of Go

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
   - "1.10"
   - "1.11"
   - "1.12"
+  - "1.13"
 
 script: make unit && make integration
 
@@ -17,4 +18,4 @@ jobs:
     - stage: check
       install: go get golang.org/x/lint/golint github.com/kisielk/errcheck
       script: make lint && make errcheck
-      go: "1.12" # only run source code analysis tools on latest version of Go
+      go: "1.13" # only run source code analysis tools on latest version of Go

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,32 @@
-GOPACKAGES := $(shell go list ./...)
+PACKAGES := $(shell go list ./... | grep -v mock)
 
 .PHONY: default
-default: fmt lint unit
-
-.PHONY: errcheck
-errcheck:
-	@errcheck -asserts -blank -ignore 'io:[cC]lose' $(GOPACKAGES)
+default: fmt lint
 
 .PHONY: fmt
+## fmt: runs go fmt on source files
 fmt:
 	@go fmt $(PACKAGES)
 
+.PHONY: help
+## help: prints this help message
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
 .PHONY: integration
+## integration: runs the integration tests
 integration:
-	@sh ./scripts/integration_test.sh $(GOPACKAGES)
+	@go clean -testcache
+	@sh ./scripts/integration_test.sh $(PACKAGES)
 
 .PHONY: lint
+## lint: runs go lint on source files
 lint:
-	@golint -set_exit_status $(GOPACKAGES)
+	@golint -set_exit_status -min_confidence=0.3 $(PACKAGES)
 
 .PHONY: unit
+## unit: runs the unit tests
 unit:
-	@go test -cover -timeout=1s $(GOPACKAGES)
+	@go clean -testcache
+	@go test -cover -covermode=atomic -race -timeout=1s $(PACKAGES)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ make integration
 
 The integration tests expect Docker to be available on the host, using it to run a local mountebank container at 
 `localhost:2525`, with the additional ports 8080-8081 exposed for test imposters. Currently tested against a mountebank 
-v2.0.0 instance using the [andyrbell/mountebank](https://hub.docker.com/r/andyrbell/mountebank) image on DockerHub.
+v2.1.2 instance using the [andyrbell/mountebank](https://hub.docker.com/r/andyrbell/mountebank) image on DockerHub.
 
 ## Contributing
 

--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -212,7 +211,6 @@ func (cli *Client) OverwriteAllStubs(ctx context.Context, port int, stubs []Stub
 	b, err := json.Marshal(map[string]interface{}{
 		"stubs": stubs,
 	})
-	log.Printf("\ndto: %s\n", b)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -169,7 +169,7 @@ func (cli *Client) Delete(ctx context.Context, port int, replay bool) (*Imposter
 // See more information about this resource at:
 // http://www.mbtest.org/docs/api/overview#delete-imposter-requests.
 func (cli *Client) DeleteRequests(ctx context.Context, port int) (*Imposter, error) {
-	p := fmt.Sprintf("/imposters/%d/requests", port)
+	p := fmt.Sprintf("/imposters/%d/savedProxyResponses", port)
 
 	req, err := cli.restCli.NewRequest(ctx, http.MethodDelete, p, nil, nil)
 	if err != nil {

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -34,18 +34,18 @@ func newContext(timeout time.Duration) context.Context {
 	return ctx
 }
 
-func TestClient_Logs(t *testing.T) {
+func TestClient_Logs_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	vs, err := mb.Logs(newContext(time.Second), -1, -1)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(vs) >= 2, true)
-	assert.Equals(t, vs[0].Message, "[mb:2525] mountebank v2.1.2 now taking orders - point your browser to http://localhost:2525/ for help")
-	assert.Equals(t, vs[1].Message, "[mb:2525] Running with --allowInjection set. See http://localhost:2525/docs/security for security info")
-	assert.Equals(t, vs[2].Message, "[mb:2525] GET /logs")
+	assert.MustOk(t, err)
+	assert.Equals(t, true, len(vs) >= 2)
+	assert.Equals(t, "[mb:2525] mountebank v2.1.2 now taking orders - point your browser to http://localhost:2525/ for help", vs[0].Message)
+	assert.Equals(t, "[mb:2525] Running with --allowInjection set. See http://localhost:2525/docs/security for security info", vs[1].Message)
+	assert.Equals(t, "[mb:2525] GET /logs", vs[2].Message)
 }
 
-func TestClient_Create(t *testing.T) {
+func TestClient_Create_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := []struct {
@@ -119,12 +119,12 @@ func TestClient_Create(t *testing.T) {
 			},
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, mb *mbgo.Client) {
 				imp, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
-				assert.Equals(t, imp.Name, "create_test")
+				assert.MustOk(t, err)
+				assert.Equals(t, "create_test", imp.Name)
 			},
 			Expected: &mbgo.Imposter{
 				Proto:          "http",
@@ -193,11 +193,11 @@ func TestClient_Create(t *testing.T) {
 			},
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Expected: &mbgo.Imposter{
 				Proto: "tcp",
@@ -232,8 +232,12 @@ func TestClient_Create(t *testing.T) {
 			}
 
 			actual, err := mb.Create(newContext(time.Second), c.Input)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(t, mb)
@@ -242,7 +246,7 @@ func TestClient_Create(t *testing.T) {
 	}
 }
 
-func TestClient_Imposter(t *testing.T) {
+func TestClient_Imposter_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := []struct {
@@ -264,7 +268,7 @@ func TestClient_Imposter(t *testing.T) {
 			Port:        8080,
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Err: errors.New("no such resource: Try POSTing to /imposters first?"),
 		},
@@ -272,7 +276,7 @@ func TestClient_Imposter(t *testing.T) {
 			Description: "should return the expected TCP Imposter if it exists on the specified port",
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 
 				imp, err := mb.Create(newContext(time.Second), mbgo.Imposter{
 					Port:           8080,
@@ -300,13 +304,13 @@ func TestClient_Imposter(t *testing.T) {
 						},
 					},
 				})
-				assert.Equals(t, err, nil)
-				assert.Equals(t, imp.Name, "imposter_test")
+				assert.MustOk(t, err)
+				assert.Equals(t, "imposter_test", imp.Name)
 			},
 			After: func(t *testing.T, mb *mbgo.Client) {
 				imp, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
-				assert.Equals(t, imp.Name, "imposter_test")
+				assert.MustOk(t, err)
+				assert.Equals(t, "imposter_test", imp.Name)
 			},
 			Port:   8080,
 			Replay: false,
@@ -347,8 +351,12 @@ func TestClient_Imposter(t *testing.T) {
 			}
 
 			actual, err := mb.Imposter(newContext(time.Second), c.Port, c.Replay)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(t, mb)
@@ -357,7 +365,7 @@ func TestClient_Imposter(t *testing.T) {
 	}
 }
 
-func TestClient_AddStub(t *testing.T) {
+func TestClient_AddStub_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := map[string]struct {
@@ -375,7 +383,7 @@ func TestClient_AddStub(t *testing.T) {
 			Port: 8080,
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Err: errors.New("no such resource: Try POSTing to /imposters first?"),
 		},
@@ -426,11 +434,11 @@ func TestClient_AddStub(t *testing.T) {
 						},
 					},
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, client *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Expected: &mbgo.Imposter{
 				Port:  8080,
@@ -487,8 +495,12 @@ func TestClient_AddStub(t *testing.T) {
 			}
 
 			actual, err := mb.AddStub(newContext(time.Second), c.Port, c.Index, c.Stub)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(t, mb)
@@ -497,7 +509,7 @@ func TestClient_AddStub(t *testing.T) {
 	}
 }
 
-func TestClient_OverwriteStub(t *testing.T) {
+func TestClient_OverwriteStub_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := map[string]struct {
@@ -515,7 +527,7 @@ func TestClient_OverwriteStub(t *testing.T) {
 			Port: 8080,
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Err: errors.New("no such resource: Try POSTing to /imposters first?"),
 		},
@@ -566,11 +578,11 @@ func TestClient_OverwriteStub(t *testing.T) {
 						},
 					},
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, client *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Expected: &mbgo.Imposter{
 				Port:  8080,
@@ -609,8 +621,12 @@ func TestClient_OverwriteStub(t *testing.T) {
 			}
 
 			actual, err := mb.OverwriteStub(newContext(time.Second), c.Port, c.Index, c.Stub)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(t, mb)
@@ -619,7 +635,7 @@ func TestClient_OverwriteStub(t *testing.T) {
 	}
 }
 
-func TestClient_OverwriteAllStubs(t *testing.T) {
+func TestClient_OverwriteAllStubs_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := map[string]struct {
@@ -636,7 +652,7 @@ func TestClient_OverwriteAllStubs(t *testing.T) {
 			Port: 8080,
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Err: errors.New("no such resource: Try POSTing to /imposters first?"),
 		},
@@ -706,11 +722,11 @@ func TestClient_OverwriteAllStubs(t *testing.T) {
 						},
 					},
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, client *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Expected: &mbgo.Imposter{
 				Port:  8080,
@@ -767,8 +783,12 @@ func TestClient_OverwriteAllStubs(t *testing.T) {
 			}
 
 			actual, err := mb.OverwriteAllStubs(newContext(time.Second), c.Port, c.Stubs)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(t, mb)
@@ -777,7 +797,7 @@ func TestClient_OverwriteAllStubs(t *testing.T) {
 	}
 }
 
-func TestClient_RemoveStub(t *testing.T) {
+func TestClient_RemoveStub_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := map[string]struct {
@@ -794,7 +814,7 @@ func TestClient_RemoveStub(t *testing.T) {
 			Port: 8080,
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Err: errors.New("no such resource: Try POSTing to /imposters first?"),
 		},
@@ -808,11 +828,11 @@ func TestClient_RemoveStub(t *testing.T) {
 					Name:  "remove_stub_test",
 					Stubs: []mbgo.Stub{},
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, client *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Err: errors.New("bad data: 'stubIndex' must be a valid integer, representing the array index position of the stub to replace"),
 		},
@@ -845,11 +865,11 @@ func TestClient_RemoveStub(t *testing.T) {
 						},
 					},
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, client *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Expected: &mbgo.Imposter{
 				Port:  8080,
@@ -869,8 +889,12 @@ func TestClient_RemoveStub(t *testing.T) {
 			}
 
 			actual, err := mb.RemoveStub(newContext(time.Second), c.Port, c.Index)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(t, mb)
@@ -879,7 +903,7 @@ func TestClient_RemoveStub(t *testing.T) {
 	}
 }
 
-func TestClient_Delete(t *testing.T) {
+func TestClient_Delete_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := []struct {
@@ -901,7 +925,7 @@ func TestClient_Delete(t *testing.T) {
 			Port:        8080,
 			Before: func(mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Expected: &mbgo.Imposter{},
 		},
@@ -914,8 +938,12 @@ func TestClient_Delete(t *testing.T) {
 			}
 
 			actual, err := mb.Delete(newContext(time.Second), c.Port, c.Replay)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(mb)
@@ -924,7 +952,7 @@ func TestClient_Delete(t *testing.T) {
 	}
 }
 
-func TestClient_DeleteRequests(t *testing.T) {
+func TestClient_DeleteRequests_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cases := []struct {
@@ -944,7 +972,7 @@ func TestClient_DeleteRequests(t *testing.T) {
 			Description: "should error if one is not configured on the specified port",
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			Port: 8080,
 			Err:  errors.New("no such resource: Try POSTing to /imposters first?"),
@@ -953,7 +981,7 @@ func TestClient_DeleteRequests(t *testing.T) {
 			Description: "should return the expected Imposter if it exists on successful deletion",
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 
 				_, err = mb.Create(newContext(time.Second), mbgo.Imposter{
 					Port:           8080,
@@ -961,12 +989,12 @@ func TestClient_DeleteRequests(t *testing.T) {
 					Name:           "delete_requests_test",
 					RecordRequests: true,
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 			},
 			After: func(t *testing.T, mb *mbgo.Client) {
 				imp, err := mb.Delete(newContext(time.Second), 8080, false)
-				assert.Equals(t, err, nil)
-				assert.Equals(t, imp.Name, "delete_requests_test")
+				assert.MustOk(t, err)
+				assert.Equals(t, "delete_requests_test", imp.Name)
 			},
 			Port: 8080,
 			Expected: &mbgo.Imposter{
@@ -985,7 +1013,11 @@ func TestClient_DeleteRequests(t *testing.T) {
 			}
 
 			actual, err := mb.DeleteRequests(newContext(time.Second), c.Port)
-			assert.Equals(t, err, c.Err)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
 
 			if actual != nil {
 				for i := 0; i < len(actual.Requests); i++ {
@@ -1000,7 +1032,7 @@ func TestClient_DeleteRequests(t *testing.T) {
 					actual.Requests[i] = req
 				}
 
-				assert.Equals(t, actual, c.Expected)
+				assert.Equals(t, c.Expected, actual)
 			}
 
 			if c.After != nil {
@@ -1010,15 +1042,15 @@ func TestClient_DeleteRequests(t *testing.T) {
 	}
 }
 
-func TestClient_Config(t *testing.T) {
+func TestClient_Config_Integration(t *testing.T) {
 	mb := newMountebankClient()
 
 	cfg, err := mb.Config(newContext(time.Second))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, cfg.Version, "2.1.2")
+	assert.MustOk(t, err)
+	assert.Equals(t, "2.1.2", cfg.Version)
 }
 
-func TestClient_Imposters(t *testing.T) {
+func TestClient_Imposters_Integration(t *testing.T) {
 	cases := []struct {
 		// general
 		Description string
@@ -1036,7 +1068,7 @@ func TestClient_Imposters(t *testing.T) {
 			Description: "should return a minimal representation of all registered Imposters",
 			Before: func(t *testing.T, mb *mbgo.Client) {
 				_, err := mb.DeleteAll(newContext(time.Second), false)
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 
 				// create a tcp imposter
 				imp, err := mb.Create(newContext(time.Second), mbgo.Imposter{
@@ -1065,7 +1097,7 @@ func TestClient_Imposters(t *testing.T) {
 						},
 					},
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 				assert.Equals(t, imp.Name, "imposters_tcp_test")
 
 				// and an http imposter
@@ -1107,7 +1139,7 @@ func TestClient_Imposters(t *testing.T) {
 						},
 					},
 				})
-				assert.Equals(t, err, nil)
+				assert.MustOk(t, err)
 				assert.Equals(t, imp.Name, "imposters_http_test")
 			},
 			Expected: []mbgo.Imposter{
@@ -1134,8 +1166,12 @@ func TestClient_Imposters(t *testing.T) {
 			}
 
 			actual, err := mb.Imposters(newContext(time.Second), c.Replay)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, actual)
 
 			if c.After != nil {
 				c.After(t, mb)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/senseyeio/mbgo
 
-go 1.12
+go 1.13

--- a/imposter.go
+++ b/imposter.go
@@ -515,6 +515,16 @@ type Stub struct {
 	Responses []Response
 }
 
+// MarshalJSON implements the json.Marshaler interface for Stub,
+// used to map a Stub value to its JSON structure.
+func (s Stub) MarshalJSON() ([]byte, error) {
+	dto, err := s.toDTO()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(dto)
+}
+
 // toDTO maps a Stub value to a stubDTO value; used for json.Marshal.
 func (s Stub) toDTO() (stubDTO, error) {
 	dto := stubDTO{
@@ -641,15 +651,7 @@ func (imp Imposter) MarshalJSON() ([]byte, error) {
 		m["recordRequests"] = imp.RecordRequests
 	}
 	if len(imp.Stubs) > 0 {
-		stubs := make([]stubDTO, len(imp.Stubs))
-		for i, stub := range imp.Stubs {
-			v, err := stub.toDTO()
-			if err != nil {
-				return nil, err
-			}
-			stubs[i] = v
-		}
-		m["stubs"] = stubs
+		m["stubs"] = imp.Stubs
 	}
 	if imp.AllowCORS {
 		m["allowCORS"] = imp.AllowCORS

--- a/imposter_test.go
+++ b/imposter_test.go
@@ -354,6 +354,51 @@ func TestImposter_MarshalJSON(t *testing.T) {
 				},
 			},
 		},
+		{
+			Description: "should marshal the expected javascript injection predicate",
+			Imposter: mbgo.Imposter{
+				Proto: "tcp",
+				Port:  8080,
+				Stubs: []mbgo.Stub{
+					{
+						Predicates: []mbgo.Predicate{
+							{
+								Operator: "inject",
+								Request:  "request => { return Buffer.from(request.data, 'base64')[2] <= 100; }",
+							},
+						},
+						Responses: []mbgo.Response{
+							{
+								Type: "is",
+								Value: mbgo.TCPResponse{
+									Data: "c2Vjb25kIHJlc3BvbnNl",
+								},
+							},
+						},
+					},
+				},
+			},
+			Expected: map[string]interface{}{
+				"protocol": "tcp",
+				"port":     8080,
+				"stubs": []map[string]interface{}{
+					{
+						"predicates": []map[string]interface{}{
+							{
+								"inject": "request => { return Buffer.from(request.data, 'base64')[2] <= 100; }",
+							},
+						},
+						"responses": []map[string]interface{}{
+							{
+								"is": map[string]interface{}{
+									"data": "c2Vjb25kIHJlc3BvbnNl",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/imposter_test.go
+++ b/imposter_test.go
@@ -18,7 +18,6 @@ func TestImposter_MarshalJSON(t *testing.T) {
 		Description string
 		Imposter    mbgo.Imposter
 		Expected    map[string]interface{}
-		Err         error
 	}{
 		{
 			Description: "should marshal the tcp Imposter into the expected JSON",
@@ -407,18 +406,21 @@ func TestImposter_MarshalJSON(t *testing.T) {
 		t.Run(c.Description, func(t *testing.T) {
 			t.Parallel()
 
-			ab, err := json.Marshal(c.Imposter)
-			assert.Equals(t, err, c.Err)
-			eb, err := json.Marshal(c.Expected)
-			assert.Equals(t, err, nil)
+			// verify JSON structure of expected value versus actual
+			actualBytes, err := json.Marshal(c.Imposter)
+			assert.MustOk(t, err)
+
+			expectedBytes, err := json.Marshal(c.Expected)
+			assert.MustOk(t, err)
 
 			var actual, expected map[string]interface{}
-			err = json.Unmarshal(ab, &actual)
-			assert.Equals(t, err, nil)
-			err = json.Unmarshal(eb, &expected)
-			assert.Equals(t, err, nil)
+			err = json.Unmarshal(actualBytes, &actual)
+			assert.MustOk(t, err)
 
-			assert.Equals(t, actual, expected)
+			err = json.Unmarshal(expectedBytes, &expected)
+			assert.MustOk(t, err)
+
+			assert.Equals(t, expected, actual)
 		})
 	}
 }
@@ -428,7 +430,6 @@ func TestImposter_UnmarshalJSON(t *testing.T) {
 		Description string
 		JSON        map[string]interface{}
 		Expected    mbgo.Imposter
-		Err         error
 	}{
 		{
 			Description: "should unmarshal the JSON into the expected http Imposter",
@@ -576,15 +577,13 @@ func TestImposter_UnmarshalJSON(t *testing.T) {
 		t.Run(c.Description, func(t *testing.T) {
 			t.Parallel()
 
-			b, err := json.Marshal(c.JSON)
-			if err != nil {
-				t.Fatal(err)
-			}
+			actualBytes, err := json.Marshal(c.JSON)
+			assert.MustOk(t, err)
 
 			actual := mbgo.Imposter{}
-			err = json.Unmarshal(b, &actual)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, actual, c.Expected)
+			err = json.Unmarshal(actualBytes, &actual)
+			assert.MustOk(t, err)
+			assert.Equals(t, c.Expected, actual)
 		})
 	}
 }

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 Senseye Ltd. All rights reserved.
 // Use of this source code is governed by the MIT License that can be found in the LICENSE file.
 
+// Package assert is used internally by tests to make basic assertions.
 package assert
 
 import (
@@ -10,11 +11,11 @@ import (
 
 // Equals is a helper function used throughout the unit and integration
 // tests to assert deep equality between an actual and expected value.
-func Equals(tb testing.TB, actual, expected interface{}) {
+func Equals(tb testing.TB, expected, actual interface{}) {
 	tb.Helper()
 
 	if !reflect.DeepEqual(expected, actual) {
-		tb.Fatalf("\n\n\texpected: %#v\n\n\tactual: %#v\n\n", expected, actual)
+		tb.Errorf("\n\n\texpected: %#v\n\n\tactual: %#v\n\n", expected, actual)
 	}
 }
 
@@ -23,6 +24,15 @@ func Ok(tb testing.TB, err error) {
 	tb.Helper()
 
 	if err != nil {
-		tb.Fatalf("unexpected error: %#v\n\n", err)
+		tb.Errorf("unexpected error: %#v\n\n", err)
+	}
+}
+
+// MustOk fails the test now if an err is not nil.
+func MustOk(tb testing.TB, err error) {
+	tb.Helper()
+
+	if err != nil {
+		tb.Fatalf("fatal error: %#v\n\n", err)
 	}
 }

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 Senseye Ltd. All rights reserved.
 // Use of this source code is governed by the MIT License that can be found in the LICENSE file.
 
+// Package rest is used internally by the client to interact with the mountebank API.
 package rest
 
 import (

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -42,7 +42,7 @@ func TestClient_NewRequest(t *testing.T) {
 			Root:        &url.URL{},
 			Method:      "bad method",
 			AssertFunc: func(t *testing.T, _ *http.Request, err error) {
-				assert.Equals(t, err, errors.New(`net/http: invalid method "bad method"`))
+				assert.Equals(t, errors.New(`net/http: invalid method "bad method"`), err)
 			},
 		},
 		{
@@ -72,7 +72,7 @@ func TestClient_NewRequest(t *testing.T) {
 					ProtoMinor: 1,
 					Header:     http.Header{"Accept": []string{"application/json"}},
 				}
-				assert.Equals(t, actual, expected.WithContext(context.Background()))
+				assert.Equals(t, expected.WithContext(context.Background()), actual)
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func TestClient_NewRequest(t *testing.T) {
 					ProtoMinor: 1,
 					Header:     http.Header{"Accept": []string{"application/json"}},
 				}
-				assert.Equals(t, actual, expected.WithContext(context.Background()))
+				assert.Equals(t, expected.WithContext(context.Background()), actual)
 			},
 		},
 		{
@@ -106,7 +106,7 @@ func TestClient_NewRequest(t *testing.T) {
 					ProtoMinor: 1,
 					Header:     http.Header{"Accept": []string{"application/json"}},
 				}
-				assert.Equals(t, actual, expected.WithContext(context.Background()))
+				assert.Equals(t, expected.WithContext(context.Background()), actual)
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func TestClient_NewRequest(t *testing.T) {
 						"Content-Type": []string{"application/json"},
 					},
 				}
-				assert.Equals(t, actual, expected.WithContext(context.Background()))
+				assert.Equals(t, expected.WithContext(context.Background()), actual)
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestClient_NewRequest(t *testing.T) {
 						"Content-Type": []string{"application/json"},
 					},
 				}
-				assert.Equals(t, actual, expected.WithContext(context.Background()))
+				assert.Equals(t, expected.WithContext(context.Background()), actual)
 			},
 		},
 	}
@@ -212,8 +212,12 @@ func TestClient_DecodeResponseBody(t *testing.T) {
 
 			cli := rest.NewClient(nil, nil)
 			err := cli.DecodeResponseBody(c.Body, c.Value)
-			assert.Equals(t, err, c.Err)
-			assert.Equals(t, c.Value, c.Expected)
+			if c.Err != nil {
+				assert.Equals(t, c.Err, err)
+			} else {
+				assert.Ok(t, err)
+			}
+			assert.Equals(t, c.Expected, c.Value)
 		})
 	}
 }

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -8,7 +8,7 @@ docker run -d --rm --name=mountebank_test -p 2525:2525 -p 8080:8080 -p 8081:8081
     andyrbell/mountebank:2.1.2 mb --allowInjection
 
 # run integration tests and record exit code
-go test -cover -tags=integration -timeout=5s ${PACKAGES}
+go test -cover -covermode=atomic -race -run=^*_Integration$ -tags=integration -timeout=5s ${PACKAGES}
 CODE=$?
 
 # always stop the mountebank container, even on failures

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -4,7 +4,7 @@
 PACKAGES=$@
 
 # start the mountebank container at localhost:2525, with ports 8080 and 8081 for test imposters
-docker run -d --rm --name=mountebank_test -p 2525:2525 -p 8080:8080 -p 8081:8081 andyrbell/mountebank:2.0.0
+docker run -d --rm --name=mountebank_test -p 2525:2525 -p 8080:8080 -p 8081:8081 andyrbell/mountebank:2.1.2
 
 # run integration tests and record exit code
 go test -cover -tags=integration -timeout=5s ${PACKAGES}

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -4,7 +4,8 @@
 PACKAGES=$@
 
 # start the mountebank container at localhost:2525, with ports 8080 and 8081 for test imposters
-docker run -d --rm --name=mountebank_test -p 2525:2525 -p 8080:8080 -p 8081:8081 andyrbell/mountebank:2.1.2
+docker run -d --rm --name=mountebank_test -p 2525:2525 -p 8080:8080 -p 8081:8081 \
+    andyrbell/mountebank:2.1.2 mb --allowInjection
 
 # run integration tests and record exit code
 go test -cover -tags=integration -timeout=5s ${PACKAGES}


### PR DESCRIPTION
This PR updates the client with some v2.1 features in mountebank, namely:

* Support mutating stubs without restarting the imposter.
* Support using JavaScript injection to generate predicates.

The existing API should remain intact but will be expanded upon, so assuming this goes through into `master` I'll re-tag on the next minor version.